### PR TITLE
Unit tests

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -152,6 +152,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
   config_stack.push(config);
   TokenType last_token_type = TOKEN_TYPE_START;
   TokenType token_type;
+  int level = 0; // current scope level
   while (true) {
     std::string token;
     token_type = ParseToken(config_file, &token);
@@ -198,9 +199,16 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
       config_stack.top()->statements_.back().get()->child_block_.reset(
           new_config);
       config_stack.push(new_config);
+      level++;
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
-      if (last_token_type != TOKEN_TYPE_STATEMENT_END) {
+      if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
+          last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
+        break;
+      }
+      level--;
+      if (level < 0) {
+        // Error - unmatched braces.
         break;
       }
       config_stack.pop();
@@ -208,6 +216,10 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
       if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
           last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
+        break;
+      }
+      if (level != 0) {
+        // Error - unmatched braces.
         break;
       }
       return true;

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -9,3 +9,47 @@ TEST(NginxConfigParserTest, SimpleConfig) {
 
   EXPECT_TRUE(success);
 }
+
+/*
+ * The following is copied from the 11 Jan lecture.
+ */
+
+// foo bar;
+TEST(NginxConfigTest, ToString) {
+  NginxConfigStatement statement;
+  statement.tokens_.push_back("foo");
+  statement.tokens_.push_back("bar");
+
+  EXPECT_EQ(statement.ToString(0), "foo bar;\n");
+}
+
+class NginxStringConfigTest : public ::testing::Test {
+  protected:
+    bool ParseString(const std::string config_string) {
+      std::stringstream config_stream(config_string);
+      return parser_.Parse(&config_stream, &out_config_);
+    }
+    NginxConfigParser parser_;
+    NginxConfig out_config_;
+};
+
+TEST_F(NginxStringConfigTest, SimpleConfigStream) {
+  EXPECT_TRUE(ParseString("foo bar;"));
+  EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statement";
+  EXPECT_EQ("foo", out_config_.statements_.at(0)->tokens_.at(0));
+}
+
+TEST_F(NginxStringConfigTest, InvalidConfig) {
+  EXPECT_FALSE(ParseString("foo bar"));
+}
+
+TEST_F(NginxStringConfigTest, Nested) {
+  EXPECT_TRUE(ParseString("damm { foo bar; }"));
+}
+
+/*
+ * The bug we found in class.
+ */
+TEST_F(NginxStringConfigTest, UnmatchedBraces) {
+  EXPECT_FALSE(ParseString("damm { foo bar; "));
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -36,7 +36,7 @@ class NginxStringConfigTest : public ::testing::Test {
 TEST_F(NginxStringConfigTest, SimpleConfigStream) {
   EXPECT_TRUE(ParseString("foo bar;"));
   EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statement";
-  EXPECT_EQ("foo", out_config_.statements_.at(0)->tokens_.at(0));
+  EXPECT_EQ("foo", out_config_.statements_[0]->tokens_[0]);
 }
 
 TEST_F(NginxStringConfigTest, InvalidConfig) {
@@ -44,12 +44,35 @@ TEST_F(NginxStringConfigTest, InvalidConfig) {
 }
 
 TEST_F(NginxStringConfigTest, Nested) {
-  EXPECT_TRUE(ParseString("damm { foo bar; }"));
+  EXPECT_TRUE(ParseString("baz { foo bar; }"));
 }
 
 /*
  * The bug we found in class.
  */
 TEST_F(NginxStringConfigTest, UnmatchedBraces) {
-  EXPECT_FALSE(ParseString("damm { foo bar; "));
+  EXPECT_FALSE(ParseString("baz { foo bar; "));
+}
+
+/*
+ * The following is my own work.
+ */
+
+TEST_F(NginxStringConfigTest, NestedInvalidConfig) {
+  EXPECT_FALSE(ParseString("baz { foo }"));
+  EXPECT_FALSE(ParseString("baz { foo bar }"));
+}
+
+/*
+ * This test failed before my patch. Our parser did not allow for multiple
+ * nested blocks.
+ */
+TEST_F(NginxStringConfigTest, DeeplyNested) {
+  std::string nest = "";
+  nest += "outer {\n";
+  nest += "inner {\n";
+  nest += "hello world;\n";
+  nest += "}\n";
+  nest += "}\n";
+  EXPECT_TRUE(ParseString(nest));
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -76,3 +76,9 @@ TEST_F(NginxStringConfigTest, DeeplyNested) {
   nest += "}\n";
   EXPECT_TRUE(ParseString(nest));
 }
+
+TEST_F(NginxStringConfigTest, SampleFile) {
+  NginxConfigParser parser;
+  NginxConfig out_config;
+  EXPECT_TRUE(parser.Parse("example_config_2", &out_config));
+}

--- a/example_config_2
+++ b/example_config_2
@@ -1,0 +1,70 @@
+user       www www;  ## Default: nobody
+worker_processes  5;  ## Default: 1
+error_log  logs/error.log;
+pid        logs/nginx.pid;
+worker_rlimit_nofile 8192;
+
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+http {
+  include    conf/mime.types;
+  include    /etc/nginx/proxy.conf;
+  include    /etc/nginx/fastcgi.conf;
+  index    index.html index.htm index.php;
+
+  default_type application/octet-stream;
+  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+    '"$request" $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log   logs/access.log  main;
+  sendfile     on;
+  tcp_nopush   on;
+  server_names_hash_bucket_size 128; # this seems to be required for some vhosts
+
+  server { # php/fastcgi
+    listen       80;
+    server_name  domain1.com www.domain1.com;
+    access_log   logs/domain1.access.log  main;
+    root         html;
+
+    location ~ \.php$ {
+      fastcgi_pass   127.0.0.1:1025;
+    }
+  }
+
+  server { # simple reverse-proxy
+    listen       80;
+    server_name  domain2.com www.domain2.com;
+    access_log   logs/domain2.access.log  main;
+
+    # serve static files
+    location ~ ^/(images|javascript|js|css|flash|media|static)/  {
+      root    /var/www/virtual/big.server.com/htdocs;
+      expires 30d;
+    }
+
+    # pass requests for dynamic content to rails/turbogears/zope, et al
+    location / {
+      proxy_pass      http://127.0.0.1:8080;
+    }
+  }
+
+  upstream big_server_com {
+    server 127.0.0.3:8000 weight=5;
+    server 127.0.0.3:8001 weight=5;
+    server 192.168.0.1:8000;
+    server 192.168.0.1:8001;
+  }
+
+  server { # simple load balancing
+    listen          80;
+    server_name     big.server.com;
+    access_log      logs/big.server.access.log main;
+
+    location / {
+      proxy_pass      http://big_server_com;
+    }
+  }
+}


### PR DESCRIPTION
Add basic unit tests for the nginx config parser. Fixed bug where nested blocks would not parse. For example, this config:

```
foo {
  bar {
    baz;
  }
}
```

... would not parse, despite being syntactically valid. Additionally, configs like this:

```
foo { bar;
```

... would parse, despite being syntactically valid. My patch fixes both of these bugs.